### PR TITLE
Added list tags api definition.

### DIFF
--- a/esa-api.json
+++ b/esa-api.json
@@ -1209,6 +1209,39 @@
         }
       }
     },
+    "/teams/{team_name}/tags": {
+      "get": {
+        "summary": "タグ一覧をタグ付けされた記事数の降順で取得する",
+        "operationId": "getTags",
+        "tags": ["tag", "esa"],
+        "parameters": [
+          { "$ref": "#/components/parameters/teamName" },
+          { "$ref": "#/components/parameters/paginationPage" },
+          { "$ref": "#/components/parameters/paginationPerPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedTags" }
+              }
+            },
+            "headers": {
+              "X-RateLimit-Limit": {
+                "$ref": "#/components/headers/X-RateLimit-Limit"
+              },
+              "X-RateLimit-Remaining": {
+                "$ref": "#/components/headers/X-RateLimit-Remaining"
+              },
+              "X-RateLimit-Reset": {
+                "$ref": "#/components/headers/X-RateLimit-Reset"
+              }
+            }
+          }
+        }
+      }
+    },
     "/user": {
       "get": {
         "summary": "認証中のユーザーを取得する",
@@ -2000,6 +2033,58 @@
           "max_per_page"
         ]
       },
+      "PaginatedTags": {
+        "title": "PaginatedTags",
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "description": "Tagのリスト",
+            "items": { "$ref": "#/components/schemas/Tag" }
+          },
+          "prev_page": {
+            "type": "integer",
+            "nullable": true,
+            "description": "1つ前のpage番号。存在しない場合はnull",
+            "example": null
+          },
+          "next_page": {
+            "type": "integer",
+            "nullable": true,
+            "description": "1つ先のpage番号。存在しない場合はnull",
+            "example": 2
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "リソースの総数",
+            "example": 30
+          },
+          "page": {
+            "type": "integer",
+            "description": "現在のページ番号",
+            "example": 1
+          },
+          "per_page": {
+            "type": "integer",
+            "description": "1ページあたりに含まれる要素数",
+            "example": 20
+          },
+          "max_per_page": {
+            "type": "integer",
+            "description": "per_pageに指定可能な数の最大値",
+            "example": 100
+          }
+        },
+        "required": [
+          "tags",
+          "prev_page",
+          "next_page",
+          "total_count",
+          "page",
+          "per_page",
+          "max_per_page"
+        ]
+      },
       "PaginatedTeams": {
         "title": "PaginatedTeams",
         "type": "object",
@@ -2308,6 +2393,24 @@
           }
         },
         "required": ["created_at", "body", "user"]
+      },
+      "Tag": {
+        "title": "Tag",
+        "description": "記事のタグ",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "タグ名です。",
+            "example": "markdown"
+          },
+          "posts_count": {
+            "type": "integer",
+            "description": "タグ付けされた記事数です。",
+            "example": 1
+          }
+        },
+        "required": ["name", "posts_count"]
       },
       "Team": {
         "title": "Team",
@@ -2631,6 +2734,11 @@
       "name": "star",
       "description": "記事やコメントのStarに関するAPIです。",
       "x-displayName": "Star"
+    },
+    {
+      "name": "tag",
+      "description": "記事のタグに関するAPIです。",
+      "x-displayName": "タグ"
     },
     {
       "name": "team",

--- a/paths/teams/{team_name}/tags.ts
+++ b/paths/teams/{team_name}/tags.ts
@@ -1,0 +1,21 @@
+import { PathItemObject } from "openapi3-ts";
+import { parameterRef, parametersRef, schemaRef } from "../../../dsl";
+import { teamName } from "../../../parameters/teamName";
+import { pagination } from "../../../parameters/pagination";
+import { ok } from "../../../responses/ok";
+import { paginatedTags } from "../../../schemas/paginatedTags";
+import { tags } from "../../../tags";
+
+const teamTags: PathItemObject = {
+  get: {
+    summary: "タグ一覧をタグ付けされた記事数の降順で取得する",
+    operationId: "getTags",
+    tags: [tags.tag],
+    parameters: [parameterRef(teamName), ...parametersRef(pagination)],
+    responses: {
+      "200": ok(schemaRef(paginatedTags)),
+    },
+  },
+};
+
+export default teamTags;

--- a/schemas/paginatedTags.ts
+++ b/schemas/paginatedTags.ts
@@ -1,0 +1,9 @@
+import { schemaRef } from "../dsl";
+import { paginatedObjects } from "./paginatedObjects";
+import { tag } from "./tag";
+
+export const paginatedTags = paginatedObjects(
+  "tags",
+  tag.title,
+  schemaRef(tag)
+);

--- a/schemas/tag.ts
+++ b/schemas/tag.ts
@@ -1,0 +1,20 @@
+import { schema } from "../dsl";
+
+export const tag = schema({
+  title: "Tag",
+  description: "記事のタグ",
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      description: "タグ名です。",
+      example: "markdown",
+    },
+    posts_count: {
+      type: "integer",
+      description: "タグ付けされた記事数です。",
+      example: 1,
+    },
+  },
+  required: ["name", "posts_count"],
+} as const);

--- a/spec.ts
+++ b/spec.ts
@@ -34,10 +34,12 @@ import { paginatedComments } from "./schemas/paginatedComments";
 import { paginatedMembers } from "./schemas/paginatedMembers";
 import { paginatedPosts } from "./schemas/paginatedPosts";
 import { paginatedStargazers } from "./schemas/paginatedStargazers";
+import { paginatedTags } from "./schemas/paginatedTags";
 import { paginatedTeams } from "./schemas/paginatedTeams";
 import { paginatedWatchers } from "./schemas/paginatedWatchers";
 import { post } from "./schemas/post";
 import { stargazer } from "./schemas/stargazer";
+import { tag } from "./schemas/tag";
 import { team } from "./schemas/team";
 import { teamStats } from "./schemas/teamStats";
 import { user } from "./schemas/user";
@@ -102,10 +104,12 @@ export async function getSpec(): Promise<OpenAPIObject> {
       paginatedMembers,
       paginatedPosts,
       paginatedStargazers,
+      paginatedTags,
       paginatedTeams,
       paginatedWatchers,
       post,
       stargazer,
+      tag,
       team,
       teamStats,
       updateCommentBody,

--- a/tags.ts
+++ b/tags.ts
@@ -34,6 +34,10 @@ const tags = $tags({
     description: "記事やコメントのStarに関するAPIです。",
     "x-displayName": "Star",
   },
+  tag: {
+    description: "記事のタグに関するAPIです。",
+    "x-displayName": "タグ",
+  },
   team: {
     description: "所属するチームに関するAPIです。",
     "x-displayName": "チーム",


### PR DESCRIPTION
2021/11/21にチームのタグ一覧を取得するAPIが追加されていたので、その定義を追記しました。

https://docs.esa.io/posts/102/revisions/116